### PR TITLE
Change crc64.New() to return hash.Hash64

### DIFF
--- a/crc64/crc64.go
+++ b/crc64/crc64.go
@@ -35,7 +35,7 @@ type digest struct {
 	crc uint64
 }
 
-func New() hash.Hash {
+func New() hash.Hash64 {
 	return &digest{}
 }
 


### PR DESCRIPTION
Without this you can't get crc64.Sum64() when using library for rdb file check.